### PR TITLE
fix: memory leak in FreeMemoryOutput

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,14 @@ mod woff2 {
 
   impl Drop for Woff2MemoryOut {
     fn drop(&mut self) {
+      if !self.inner.is_null() {
+        unsafe {
+          // SAFETY: if self.inner is not null, it is a valid pointer
+          // and should be created by `ConvertWOFF2ToTTF`, which can
+          // be dealloced by `FreeMemoryOutput` safely
+          FreeMemoryOutput(self.inner);
+        }
+      }
       unsafe {
         // SAFETY: WE KNOW self.data IS LEAKED FROM A VALID VEC
         // NOTE(CGQAQ): implicit drop here will free the memory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ fn convert_to_ttf(input_buf_value: &[u8]) -> Result<Woff2MemoryOut> {
   if out_buffer_len == 0 {
     return Err(Error::new(
       Status::InvalidArg,
-      "Final result is zero sized".to_owned(),
+      "Your input is invalid 'cause the output is zero in size".to_owned(),
     ));
   }
 

--- a/src/woff2_c.cpp
+++ b/src/woff2_c.cpp
@@ -23,24 +23,17 @@ extern "C"
   }
 
   bool ConvertWOFF2ToTTF(
-      const uint8_t *data, size_t length, Woff2MemoryOut *out)
+      const uint8_t *data, size_t length,
+      uint8_t *out_buffer, size_t out_buffer_length,Woff2MemoryOut *out)
   {
     if (!data || !length || !out) {
       return false;
     }
 
-    std::allocator<uint8_t> alloc;
-    size_t result_length = woff2::ComputeWOFF2FinalSize(data, length);
-    if (result_length == 0)
-    {
-      return false;
-    }
-    // the actually size could be larger than the `result_length`, give it a little more space
-    uint8_t *result = alloc.allocate(result_length + 4096);
-    auto memory_out = new woff2::WOFF2MemoryOut(result, result_length + 4096);
+    auto memory_out = new woff2::WOFF2MemoryOut(out_buffer, out_buffer_length);
     out->inner = reinterpret_cast<Woff2MemoryOutInner *>(memory_out);
-    out->data = result;
-    out->length = result_length;
+    out->data = out_buffer;
+    out->length = out_buffer_length;
     return woff2::ConvertWOFF2ToTTF(data, length, memory_out);
   }
 

--- a/src/woff2_c.cpp
+++ b/src/woff2_c.cpp
@@ -7,6 +7,11 @@ extern "C"
     return woff2::MaxWOFF2CompressedSize(data, length);
   }
 
+  size_t ComputeWOFF2FinalSize(const uint8_t *data, size_t length)
+  {
+    return woff2::ComputeWOFF2FinalSize(data, length);
+  }
+
   bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
                          uint8_t *result, size_t *result_length, Woff2EncodeParams params)
   {

--- a/src/woff2_c.hpp
+++ b/src/woff2_c.hpp
@@ -26,7 +26,9 @@ struct Woff2EncodeParams
 extern "C"
 {
   size_t MaxWOFF2CompressedSize(const uint8_t *data, size_t length);
+
   size_t ComputeWOFF2FinalSize(const uint8_t *data, size_t length);
+
   bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
                          uint8_t *result, size_t *result_length, Woff2EncodeParams params);
 

--- a/src/woff2_c.hpp
+++ b/src/woff2_c.hpp
@@ -26,6 +26,7 @@ struct Woff2EncodeParams
 extern "C"
 {
   size_t MaxWOFF2CompressedSize(const uint8_t *data, size_t length);
+  size_t ComputeWOFF2FinalSize(const uint8_t *data, size_t length);
   bool ConvertTTFToWOFF2(const uint8_t *data, size_t length,
                          uint8_t *result, size_t *result_length, Woff2EncodeParams params);
 

--- a/src/woff2_c.hpp
+++ b/src/woff2_c.hpp
@@ -30,7 +30,8 @@ extern "C"
                          uint8_t *result, size_t *result_length, Woff2EncodeParams params);
 
   bool ConvertWOFF2ToTTF(
-      const uint8_t *data, size_t length, Woff2MemoryOut *out);
+      const uint8_t *data, size_t length,
+      uint8_t *out_buffer, size_t out_buffer_length,Woff2MemoryOut *out);
 
   void FreeMemoryOutput(Woff2MemoryOutInner *out);
 }


### PR DESCRIPTION
The woff2::WOFF2MemoryOut defined as such:
```cpp
/**
 * Fixed memory block for woff2 out.
 */
class WOFF2MemoryOut : public WOFF2Out {
 public:
  // Create a writer that writes its data to buf.
  WOFF2MemoryOut(uint8_t* buf, size_t buf_size);

  bool Write(const void *buf, size_t n) override;
  bool Write(const void *buf, size_t offset, size_t n) override;
  size_t Size() override { return offset_; }
 private:
  uint8_t* buf_;
  size_t buf_size_;
  size_t offset_;
};
```

as you can see, it doesn't have a destructor about free the underlying buffer, so `delete reinterpret_cast<woff2::WOFF2MemoryOut *>(out)` will introducing a memory leak