### PR TITLE
chore: upgrade zig to 0.16.0 and Node.js to 24 in CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,15 @@
       "matchDepNames": ["rustc"]
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>\\S+)\\s+#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)"
+      ]
+    }
+  ],
   "commitMessagePrefix": "chore: ",
   "commitMessageAction": "bump up",
   "commitMessageTopic": "{{depName}} version",

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,7 +116,7 @@ jobs:
               cargo build --manifest-path rust-brotli/Cargo.toml --release --target wasm32-wasip1-threads --features "vector_scratch_space"
               yarn build:debug --target wasm32-wasip1-threads --profile wasi
 
-    name: stable - ${{ matrix.settings.target }} - node@22
+    name: stable - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v6
@@ -126,7 +126,7 @@ jobs:
         uses: actions/setup-node@v6
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - name: Print rustup toolchain version
         shell: bash
@@ -154,7 +154,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
         if: ${{ contains(matrix.settings.target, 'linux') }}
         with:
-          version: 0.14.1
+          version: 0.16.0 # renovate: datasource=github-tags depName=ziglang/zig
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
         if: ${{ contains(matrix.settings.target, 'linux') }}
@@ -372,7 +372,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build


### PR DESCRIPTION
## Summary

- Bump zig `0.14.1` → `0.16.0` in the `goto-bus-stop/setup-zig` step
- Bump Node.js `22` → `24` in `setup-node` steps
- Add a Renovate custom regex manager + `# renovate:` marker so the zig version is bumped automatically from `ziglang/zig` tags going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and Renovate config; no application runtime, auth, or data paths are touched, though toolchain upgrades could surface build-only breakage.
> 
> **Overview**
> **CI** now builds and runs several jobs on **Node.js 24** instead of **22** (matrix job label, main `setup-node`, WASI tests, and related steps shown in the diff).
> 
> **Linux cross-compiles** pick up **Zig 0.16.0** (from 0.14.1) via `goto-bus-stop/setup-zig`, with an inline `# renovate: datasource=github-tags depName=ziglang/zig` marker so future zig releases can be tracked automatically.
> 
> **Renovate** gains a **custom regex manager** that scans `.github/workflows/*.yml` for that comment pattern and extracts `currentValue`, `datasource`, and `depName`—aligned with the existing rust toolchain rule that already uses `custom.regex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d946f4750cdb2be09c4c1ffafbd31be3ab812299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->